### PR TITLE
feat: 사용자 인증/인가, 공통 예외 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jwt
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/trellocopy/config/JwtAuthenticationToken.java
+++ b/src/main/java/com/sparta/trellocopy/config/JwtAuthenticationToken.java
@@ -1,0 +1,21 @@
+package com.sparta.trellocopy.config;
+
+import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final AuthUser authUser;
+
+    public JwtAuthenticationToken(AuthUser authUser) {
+        super(authUser.getAuthorities());
+        this.authUser = authUser;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {return null;}
+
+    @Override
+    public Object getPrincipal() {return authUser;}
+}

--- a/src/main/java/com/sparta/trellocopy/config/JwtSecurityFilter.java
+++ b/src/main/java/com/sparta/trellocopy/config/JwtSecurityFilter.java
@@ -1,0 +1,65 @@
+package com.sparta.trellocopy.config;
+
+import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import com.sparta.trellocopy.domain.user.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtSecurityFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String jwt = jwtUtil.substringToken(authorizationHeader);
+            try{
+                Claims claims = jwtUtil.extractClaims(jwt);
+                Long userId = Long.valueOf(claims.getSubject());
+                String email = claims.get("email", String.class);
+                UserRole userRole = UserRole.of(claims.get("userRole", String.class));
+
+                if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                    AuthUser authUser = new AuthUser(userId, email, userRole);
+
+                    JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
+                    authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                }
+            }catch (SecurityException | MalformedJwtException e) {
+                log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
+            } catch (ExpiredJwtException e) {
+                log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+            } catch (UnsupportedJwtException e) {
+                log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+            } catch (Exception e) {
+                log.error("Internal server error", e);
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/config/JwtUtil.java
+++ b/src/main/java/com/sparta/trellocopy/config/JwtUtil.java
@@ -1,0 +1,80 @@
+package com.sparta.trellocopy.config;
+
+import com.sparta.trellocopy.domain.common.exception.NotFoundException;
+import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import com.sparta.trellocopy.domain.user.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long TOKEN_TIME= 60 * 60 & 1000L;
+
+    @Value("${JWT_SECRET_KEY}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("email", email)
+                        .claim("userRole", userRole)
+                        .claim("nickname", nickname)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        throw new NotFoundException("Not Found Token");
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public AuthUser getAuthUserFromClaims(Claims claims) {
+        long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+        String userRole = claims.get("userRole", String.class);
+
+        return new AuthUser(userId, email, UserRole.valueOf(userRole));
+    }
+
+    public String getTokenFromRequest(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/trellocopy/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.sparta.trellocopy.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    private final JwtSecurityFilter jwtSecurityFilter;
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {return new BCryptPasswordEncoder();}
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtSecurityFilter, SecurityContextHolderAwareRequestFilter.class)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)).build();
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/common/exception/BadRequestException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.sparta.trellocopy.domain.common.exception;
+
+public class BadRequestException extends RuntimeException{
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    public BadRequestException() {super(MESSAGE);}
+
+    public BadRequestException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/common/exception/ForbiddenException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/common/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.sparta.trellocopy.domain.common.exception;
+
+public class ForbiddenException extends RuntimeException{
+    private static final String MESSAGE = "접근이 금지되었습니다.";
+
+    public ForbiddenException() {super(MESSAGE);}
+
+    public ForbiddenException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/common/exception/NotFoundException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.sparta.trellocopy.domain.common.exception;
+
+public class NotFoundException extends RuntimeException{
+    private static final String MESSAGE = "리소스를 찾을 수 없습니다.";
+
+    public NotFoundException() {super(MESSAGE);}
+
+    public NotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/common/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.sparta.trellocopy.domain.common.exception;
+
+public class UnauthorizedException extends RuntimeException{
+    private static final String MESSAGE = "인증이 필요합니다.";
+
+    public UnauthorizedException() {super(MESSAGE);}
+
+    public UnauthorizedException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/AuthUser.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/AuthUser.java
@@ -1,0 +1,55 @@
+package com.sparta.trellocopy.domain.user.dto;
+
+import com.sparta.trellocopy.domain.user.entity.UserRole;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class AuthUser implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final UserRole userRole;
+
+    public AuthUser(Long id, String email, UserRole userRole) {
+        this.id = id;
+        this.email = email;
+        this.userRole = userRole;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(userRole.name()));
+
+        if (userRole == UserRole.ROLE_ADMIN) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_USER.name()));
+        }
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {return null;}
+
+    @Override
+    public String getUsername() {return null;}
+
+    @Override
+    public boolean isAccountNonExpired() {return true;}
+
+    @Override
+    public boolean isAccountNonLocked() {return true;}
+
+    @Override
+    public boolean isCredentialsNonExpired() {return true;}
+
+    @Override
+    public boolean isEnabled() {return true;}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/User.java
@@ -1,0 +1,35 @@
+package com.sparta.trellocopy.domain.user.entity;
+
+import com.sparta.trellocopy.domain.common.entity.Timestamped;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class User extends Timestamped {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private UserRole role;
+
+    private Boolean deleted;
+
+    @Builder
+    private User(String email, String password, UserRole role, Boolean deleted) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.deleted = deleted;
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/UserRole.java
@@ -1,0 +1,16 @@
+package com.sparta.trellocopy.domain.user.entity;
+
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+
+import java.util.Arrays;
+
+public enum UserRole {
+    ROLE_USER, ROLE_ADMIN;
+
+    public static UserRole of(String role) {
+        return Arrays.stream(UserRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("유효하지 않은 UerRole"));
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.exception;
+
+import com.sparta.trellocopy.domain.common.exception.NotFoundException;
+
+public class UserNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "회원정보를 찾을 수 없습니다.";
+
+    public UserNotFoundException() {super(MESSAGE);}
+
+    public UserNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.trellocopy.domain.user.repository;
+
+import com.sparta.trellocopy.domain.user.entity.User;
+import com.sparta.trellocopy.domain.user.exception.UserNotFoundException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    default User findByIdOrElseThrow(Long userId) {
+        return findById(userId).orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/service/UserService.java
@@ -1,0 +1,15 @@
+package com.sparta.trellocopy.domain.user.service;
+
+import com.sparta.trellocopy.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=trellocopy

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: trellocopy
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
* 사용자 인증/인가를 구현했습니다.
* 공통 예외를 정의했습니다.
  * 예외는 공통적으로 정의된 예외와 도메인 별로 정의된 예외로 나뉘어 있습니다
  * 각 도메인에 맞는 예외를 구현하실 때에 `domain/common/exception` 아래에 있는 예외중에서 반환할 상태코드를 확인하시고 상속받으신 후에 구현하시면 됩니다.
    * 400 Bad Request : `BadRequestException`
    * 401 Unauthorized : `UnauthorizedException`
    * 403 Forbidden : `ForbiddenException`
    * 404 Not Found : `NotFoundException`
    * 500 Internal Server Error : `RuntimeException`
