### PR TITLE
add: `User` 관련 CRUD, 연관관계 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/sparta/trellocopy/config/JwtUtil.java
+++ b/src/main/java/com/sparta/trellocopy/config/JwtUtil.java
@@ -2,6 +2,7 @@ package com.sparta.trellocopy.config;
 
 import com.sparta.trellocopy.domain.common.exception.NotFoundException;
 import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import com.sparta.trellocopy.domain.user.entity.User;
 import com.sparta.trellocopy.domain.user.entity.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -36,15 +37,14 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
+    public String createToken(User user) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(String.valueOf(userId))
-                        .claim("email", email)
-                        .claim("userRole", userRole)
-                        .claim("nickname", nickname)
+                        .setSubject(String.valueOf(user.getId()))
+                        .claim("email", user.getEmail())
+                        .claim("userRole", user.getRole())
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/com/sparta/trellocopy/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/controller/AuthController.java
@@ -1,0 +1,41 @@
+package com.sparta.trellocopy.domain.user.controller;
+
+import com.sparta.trellocopy.domain.user.dto.request.GrantRequest;
+import com.sparta.trellocopy.domain.user.dto.request.LoginRequest;
+import com.sparta.trellocopy.domain.user.dto.request.UserJoinRequest;
+import com.sparta.trellocopy.domain.user.dto.response.LoginResponse;
+import com.sparta.trellocopy.domain.user.dto.response.UserJoinResponse;
+import com.sparta.trellocopy.domain.user.dto.response.UserResponse;
+import com.sparta.trellocopy.domain.user.dto.response.WorkspaceUserResponse;
+import com.sparta.trellocopy.domain.user.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/join")
+    public ResponseEntity<UserJoinResponse> join(@RequestBody UserJoinRequest userJoinRequest) {
+        UserJoinResponse userJoinResponse = authService.join(userJoinRequest);
+        return ResponseEntity.ok(userJoinResponse);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        LoginResponse loginResponse = authService.login(loginRequest);
+        return ResponseEntity.ok(loginResponse);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/grant")
+    public ResponseEntity<WorkspaceUserResponse> grantWorkspace(@RequestBody GrantRequest grantRequest) {
+        WorkspaceUserResponse workspaceUserResponse = authService.grant(grantRequest);
+        return ResponseEntity.ok(workspaceUserResponse);
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.sparta.trellocopy.domain.user.controller;
+
+import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import com.sparta.trellocopy.domain.user.dto.request.WithdrawRequest;
+import com.sparta.trellocopy.domain.user.dto.response.UserResponse;
+import com.sparta.trellocopy.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getUser(@AuthenticationPrincipal AuthUser authUser) {
+        UserResponse userResponse = userService.findById(authUser);
+        return ResponseEntity.ok(userResponse);
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@RequestBody WithdrawRequest withdrawRequest,
+                                         @AuthenticationPrincipal AuthUser authUser) {
+        userService.withdraw(withdrawRequest, authUser);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/request/GrantRequest.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/request/GrantRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.trellocopy.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class GrantRequest {
+
+    private Long workspaceId;
+
+    private Long userId;
+
+    private String role;
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    private String email;
+
+    private String password;
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/request/UserJoinRequest.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/request/UserJoinRequest.java
@@ -1,0 +1,21 @@
+package com.sparta.trellocopy.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UserJoinRequest {
+
+    @Email(message = "이메일 형식이어야 합니다.")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$",
+            message = "비밀번호는 대소문자 영문, 숫자, 특수문자를 각각 최소 1글자 이상 포함해야 합니다.")
+    private String password;
+
+    private String role;
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,8 @@
+package com.sparta.trellocopy.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class WithdrawRequest {
+    private String password;
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.trellocopy.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private String token;
+
+    @Builder
+    private LoginResponse(String token) {this.token = token;}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/response/UserJoinResponse.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/response/UserJoinResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.trellocopy.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserJoinResponse {
+
+    private String token;
+
+    @Builder
+    private UserJoinResponse(String token) {this.token = token;}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.trellocopy.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+
+    private String email;
+
+    private String role;
+
+    @Builder
+    private UserResponse(String email, String role) {
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/dto/response/WorkspaceUserResponse.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/dto/response/WorkspaceUserResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.trellocopy.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class WorkspaceUserResponse {
+    private Long workspaceId;
+    private String email;
+    private String workspaceRole;
+
+    @Builder
+    private WorkspaceUserResponse(Long workspaceId, String email, String workspaceRole) {
+        this.workspaceId = workspaceId;
+        this.email = email;
+        this.workspaceRole = workspaceRole;
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/CardUser.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/CardUser.java
@@ -15,8 +15,10 @@ public class CardUser {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id")
     private Card card;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 }

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/CardUser.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/CardUser.java
@@ -1,0 +1,22 @@
+package com.sparta.trellocopy.domain.user.entity;
+
+import com.sparta.trellocopy.domain.card.entity.Card;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class CardUser {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Card card;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/User.java
@@ -1,35 +1,39 @@
 package com.sparta.trellocopy.domain.user.entity;
 
 import com.sparta.trellocopy.domain.common.entity.Timestamped;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE user SET deleted = 'true' WHERE user_id = ?")
+@SQLRestriction("status != 'WITHDRAWN'")
 @Entity
 public class User extends Timestamped {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
 
     private String password;
 
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @ColumnDefault("0")
     private Boolean deleted;
 
     @Builder
-    private User(String email, String password, UserRole role, Boolean deleted) {
+    private User(String email, String password, UserRole role) {
         this.email = email;
         this.password = password;
         this.role = role;
-        this.deleted = deleted;
     }
 }

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceRole.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceRole.java
@@ -1,0 +1,16 @@
+package com.sparta.trellocopy.domain.user.entity;
+
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+
+import java.util.Arrays;
+
+public enum WorkspaceRole {
+    WORKSPACE, BOARD, READ_ONLY;
+
+    public static WorkspaceRole of(String role) {
+        return Arrays.stream(WorkspaceRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("유효하지 않은 WorkspaceRole"));
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceUser.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceUser.java
@@ -1,0 +1,37 @@
+package com.sparta.trellocopy.domain.user.entity;
+
+import com.sparta.trellocopy.domain.workspace.entity.WorkSpace;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class WorkspaceUser {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WorkSpace workspace;
+
+    @Enumerated(EnumType.STRING)
+    private WorkspaceRole role;
+
+    @Builder
+    private WorkspaceUser(User user, WorkSpace workspace, WorkspaceRole role) {
+        this.user = user;
+        this.workspace = workspace;
+        this.role = role;
+    }
+
+    public void updateRole(WorkspaceRole role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceUser.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/entity/WorkspaceUser.java
@@ -16,9 +16,11 @@ public class WorkspaceUser {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workspace_id")
     private WorkSpace workspace;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/sparta/trellocopy/domain/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.exception;
+
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+
+public class DuplicateUserException extends BadRequestException {
+    private static final String MESSAGE = "중복된 사용자입니다.";
+
+    public DuplicateUserException() {super(MESSAGE);}
+
+    public DuplicateUserException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/exception/InvalidPasswordException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/exception/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.exception;
+
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+
+public class InvalidPasswordException extends BadRequestException {
+    private static final String MESSAGE = "잘못된 비밀번호입니다.";
+
+    public InvalidPasswordException() {super(MESSAGE);}
+
+    public InvalidPasswordException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/exception/WithdrawnUserException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/exception/WithdrawnUserException.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.exception;
+
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+
+public class WithdrawnUserException extends BadRequestException {
+    private static final String MESSAGE = "탈퇴한 사용자입니다.";
+
+    public WithdrawnUserException() {super(MESSAGE);}
+
+    public WithdrawnUserException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/exception/WorkspaceUserNotFoundException.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/exception/WorkspaceUserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sparta.trellocopy.domain.user.exception;
+
+import com.sparta.trellocopy.domain.common.exception.NotFoundException;
+
+public class WorkspaceUserNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "워크스페이스 혹은 사용자를 찾을 수 없습니다";
+
+    public WorkspaceUserNotFoundException() {super(MESSAGE);}
+
+    public WorkspaceUserNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/repository/CardUserRepository.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/repository/CardUserRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.trellocopy.domain.user.repository;
+
+import com.sparta.trellocopy.domain.user.entity.CardUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CardUserRepository extends JpaRepository<CardUser, Long> {
+
+    @Query("SELECT cu FROM CardUser cu JOIN FETCH cu.user WHERE cu.card.id = :cardId")
+    List<CardUser> findByCardId(@Param("cardId") Long cardId);
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/repository/UserRepository.java
@@ -3,10 +3,21 @@ package com.sparta.trellocopy.domain.user.repository;
 import com.sparta.trellocopy.domain.user.entity.User;
 import com.sparta.trellocopy.domain.user.exception.UserNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 
     default User findByIdOrElseThrow(Long userId) {
         return findById(userId).orElseThrow(UserNotFoundException::new);
     }
+
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailIncludingWithdrawn(@Param("email") String email);
 }

--- a/src/main/java/com/sparta/trellocopy/domain/user/repository/WorkspaceUserRepository.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/repository/WorkspaceUserRepository.java
@@ -1,0 +1,19 @@
+package com.sparta.trellocopy.domain.user.repository;
+
+import com.sparta.trellocopy.domain.user.entity.WorkspaceUser;
+import com.sparta.trellocopy.domain.workspace.entity.WorkSpace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkspaceUserRepository extends JpaRepository<WorkspaceUser, Long> {
+
+    @Query("SELECT wu FROM WorkspaceUser wu JOIN FETCH wu.user WHERE wu.workspace.id = :workspaceId AND wu.user.id = :userId")
+    Optional<WorkspaceUser> findByWorkspaceIdAndUserId(@Param("workspaceId") Long workspaceId, @Param("userId") Long userId);
+
+    @Query("SELECT wu.workspace FROM WorkspaceUser wu JOIN FETCH wu.workspace WHERE wu.user.id = :userId")
+    List<WorkSpace> findAllWorkspacesByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/service/AuthService.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/service/AuthService.java
@@ -1,0 +1,98 @@
+package com.sparta.trellocopy.domain.user.service;
+
+import com.sparta.trellocopy.config.JwtUtil;
+import com.sparta.trellocopy.domain.common.exception.BadRequestException;
+import com.sparta.trellocopy.domain.common.exception.NotFoundException;
+import com.sparta.trellocopy.domain.user.dto.request.GrantRequest;
+import com.sparta.trellocopy.domain.user.dto.request.LoginRequest;
+import com.sparta.trellocopy.domain.user.dto.request.UserJoinRequest;
+import com.sparta.trellocopy.domain.user.dto.response.LoginResponse;
+import com.sparta.trellocopy.domain.user.dto.response.UserJoinResponse;
+import com.sparta.trellocopy.domain.user.dto.response.UserResponse;
+import com.sparta.trellocopy.domain.user.dto.response.WorkspaceUserResponse;
+import com.sparta.trellocopy.domain.user.entity.User;
+import com.sparta.trellocopy.domain.user.entity.UserRole;
+import com.sparta.trellocopy.domain.user.entity.WorkspaceRole;
+import com.sparta.trellocopy.domain.user.entity.WorkspaceUser;
+import com.sparta.trellocopy.domain.user.exception.*;
+import com.sparta.trellocopy.domain.user.repository.UserRepository;
+import com.sparta.trellocopy.domain.user.repository.WorkspaceUserRepository;
+import com.sparta.trellocopy.domain.workspace.entity.WorkSpace;
+import com.sparta.trellocopy.domain.workspace.repository.WorkSpaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final WorkSpaceRepository workSpaceRepository;
+    private final WorkspaceUserRepository workspaceUserRepository;
+    private final PasswordEncoder passwordEncoder;
+    private JwtUtil jwtUtil;
+
+    @Transactional
+    public UserJoinResponse join(UserJoinRequest userJoinRequest) {
+
+        String email = userJoinRequest.getEmail();
+
+        if (userRepository.existsByEmail(email)) {
+            throw new BadRequestException("이미 존재하는 이메일입니다.");
+        }
+
+        Optional<User> optionalUser = userRepository.findByEmailIncludingWithdrawn(email);
+        if (optionalUser.isPresent()) {
+            if (optionalUser.get().getDeleted()) {
+                throw new WithdrawnUserException("탈퇴한 사용자의 아이디는 재사용할 수 없습니다.");
+            }
+            throw new DuplicateUserException();
+        }
+
+        String encodedPassword = passwordEncoder.encode(userJoinRequest.getPassword());
+        UserRole role = UserRole.of(userJoinRequest.getRole());
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .role(role)
+                .build();
+
+        userRepository.save(user);
+
+        String token = jwtUtil.createToken(user);
+
+        return UserJoinResponse.builder().token(token).build();
+    }
+
+    public LoginResponse login(LoginRequest loginRequest) {
+        User user = userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(() -> new UserNotFoundException("가입되지 않은 사용자입니다."));
+
+        if (passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String token = jwtUtil.createToken(user);
+
+        return LoginResponse.builder().token(token).build();
+    }
+
+    @Transactional
+    public WorkspaceUserResponse grant(GrantRequest grantRequest) {
+        User user = userRepository.findById(grantRequest.getUserId()).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+        WorkSpace workSpace = workSpaceRepository.findById(grantRequest.getWorkspaceId()).orElseThrow(() -> new NotFoundException("존재하지 않는 워크스페이스입니다."));
+        WorkspaceUser workspaceUser = workspaceUserRepository.findByWorkspaceIdAndUserId(user.getId(), workSpace.getId()).orElseThrow(WorkspaceUserNotFoundException::new);
+        workspaceUser.updateRole(WorkspaceRole.of(grantRequest.getRole()));
+
+        return WorkspaceUserResponse.builder()
+                .workspaceId(workSpace.getId())
+                .email(user.getEmail())
+                .workspaceRole(workspaceUser.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/trellocopy/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/trellocopy/domain/user/service/UserService.java
@@ -1,7 +1,13 @@
 package com.sparta.trellocopy.domain.user.service;
 
+import com.sparta.trellocopy.domain.user.dto.AuthUser;
+import com.sparta.trellocopy.domain.user.dto.request.WithdrawRequest;
+import com.sparta.trellocopy.domain.user.dto.response.UserResponse;
+import com.sparta.trellocopy.domain.user.entity.User;
+import com.sparta.trellocopy.domain.user.exception.InvalidPasswordException;
 import com.sparta.trellocopy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,5 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    public UserResponse findById(AuthUser authUser) {
+        User user = userRepository.findByIdOrElseThrow(authUser.getId());
+
+        return UserResponse.builder()
+                .email(user.getEmail())
+                .role(user.getRole().name())
+                .build();
+    }
+
+    @Transactional
+    public void withdraw(WithdrawRequest withdrawRequest, AuthUser authUser) {
+        User user = userRepository.findByIdOrElseThrow(authUser.getId());
+
+        if (!passwordEncoder.matches(withdrawRequest.getPassword(), authUser.getPassword())) {
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+        }
+
+        userRepository.delete(user);
+    }
 }


### PR DESCRIPTION
* `User` 회원가입, 로그인, 탈퇴, 조회를 구현했습니다.
* `User` 와 `Workspace` 의 중간 연관관계 엔티티인 `WorkspaceUser` 를 구현했습니다.
* `ADMIN` 만 할 수 있는 `WorkspaceRole` 권한 부여를 구현했습니다.